### PR TITLE
fix: skip Bluetooth address and UUID validation on iOS

### DIFF
--- a/lib/src/flutter_classic_bluetooth.dart
+++ b/lib/src/flutter_classic_bluetooth.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'btc_uuid.dart';
 import 'btc_reconnecting_connection.dart';
 import 'platform_interface.dart';
@@ -434,12 +436,14 @@ class FlutterClassicBluetooth {
   // ── Validation ───────────────────────────────────────────────────────
 
   void _validateAddress(String address) {
+    if (Platform.isIOS) return;
     if (!_macAddressRegex.hasMatch(address)) {
       throw BtcAddressException(address);
     }
   }
 
   void _validateUuid(String uuid) {
+    if (Platform.isIOS) return;
     if (!_uuidRegex.hasMatch(uuid)) {
       throw BtcUuidException(uuid);
     }


### PR DESCRIPTION
On iOS, Bluetooth devices are not identified by MAC addresses like on Android. Instead, iOS assigns its own UUIDs (e.g., A1B2C3D4-E5F6-7890-...) to discovered peripherals.                                                  
                                                                                                                                                                            
The original library validates device addresses against a MAC address regex (XX:XX:XX:XX:XX:XX). Since iOS identifiers never match that format, every call to connectToDevice, bondDevice, or writeToDevice throws a BtcAddressException on iOS making the library unusable on that platform.

The same issue applies to _validateUuid, the UUID format iOS provides may not match the regex the library expects.
Adding if (Platform.isIOS) return; skips these Android-specific format checks on iOS and lets the platform channel handle the identifiers natively.

This has been tested using two Bluetooth printers connected to multiple iPhones.